### PR TITLE
Fix microseconds getting ignored in utils.timedelta_to_seconds

### DIFF
--- a/hiro/utils.py
+++ b/hiro/utils.py
@@ -13,7 +13,7 @@ def timedelta_to_seconds(delta):
     """
     seconds = delta.microseconds
     seconds += (delta.seconds + delta.days * 24 * 3600) * 10 ** 6
-    return seconds / 10 ** 6
+    return float(seconds) / 10 ** 6
 
 
 

--- a/hiro/utils.py
+++ b/hiro/utils.py
@@ -1,9 +1,9 @@
 """
 random utility functions
 """
+import calendar
 import datetime
 import functools
-import time
 from .errors import InvalidTypeError
 
 
@@ -25,7 +25,7 @@ def time_in_seconds(value):
     if isinstance(value, (float, int)):
         return value
     elif isinstance(value, (datetime.date, datetime.datetime)):
-        return time.mktime(value.timetuple())
+        return calendar.timegm(value.timetuple())
     else:
         raise InvalidTypeError(value)
 

--- a/hiro/utils.py
+++ b/hiro/utils.py
@@ -43,5 +43,3 @@ def chained(method):
         result = method(self, *args, **kwargs)
         return self if result is None else result
     return wrapper
-
-

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -45,12 +45,12 @@ class TestChained(unittest.TestCase):
         self.obj = self.Foo()
 
     def test_no_return(self):
-        self.assertIs(self.obj.return_value(), self.obj)
+        self.assertTrue(self.obj.return_value() is self.obj)
 
     def test_with_return(self):
         o = object()
-        self.assertIs(self.obj.return_value(o), o)
+        self.assertTrue(self.obj.return_value(o) is o)
 
     def test_kwargs(self):
         o = object()
-        self.assertIs(self.obj.return_value(value=o), o)
+        self.assertTrue(self.obj.return_value(value=o) is o)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -31,8 +31,8 @@ class TestTimeInSeconds(unittest.TestCase):
         self.assertEqual(time_in_seconds(d), 0)
 
     def test_invalid_type(self):
-        with self.assertRaises(InvalidTypeError):
-            time_in_seconds("this is a string")
+        self.assertRaises(
+            InvalidTypeError, time_in_seconds, "this is a string")
 
 
 class TestChained(unittest.TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,56 @@
+import datetime
+import unittest
+
+import hiro
+from hiro.errors import InvalidTypeError
+from hiro.utils import timedelta_to_seconds, time_in_seconds, chained
+
+
+class TestTimeDeltaToSeconds(unittest.TestCase):
+    def test_fractional(self):
+        delta = datetime.timedelta(seconds=1, microseconds=1000)
+        self.assertAlmostEqual(timedelta_to_seconds(delta), 1.001)
+
+    def test_days(self):
+        delta = datetime.timedelta(days=10)
+        self.assertEqual(timedelta_to_seconds(delta),
+                         delta.days * 24 * 60 * 60)
+
+
+class TestTimeInSeconds(unittest.TestCase):
+    def test_passthrough(self):
+        self.assertEqual(time_in_seconds(1), 1)
+        self.assertEqual(time_in_seconds(1.0), 1.0)
+
+    def test_date(self):
+        d = datetime.date(1970, 1, 1)
+        self.assertEqual(time_in_seconds(d), 0)
+
+    def test_datetime(self):
+        d = datetime.datetime(1970, 1, 1, 0, 0, 0)
+        self.assertEqual(time_in_seconds(d), 0)
+
+    def test_invalid_type(self):
+        with self.assertRaises(InvalidTypeError):
+            time_in_seconds("this is a string")
+
+
+class TestChained(unittest.TestCase):
+    class Foo(object):
+        @chained
+        def return_value(self, value=None):
+            return value
+
+    def setUp(self):
+        self.obj = self.Foo()
+
+    def test_no_return(self):
+        self.assertIs(self.obj.return_value(), self.obj)
+
+    def test_with_return(self):
+        o = object()
+        self.assertIs(self.obj.return_value(o), o)
+
+    def test_kwargs(self):
+        o = object()
+        self.assertIs(self.obj.return_value(value=o), o)


### PR DESCRIPTION
This fixes this bug:

```python
In [3]: timedelta_to_seconds(datetime.timedelta(seconds=10, microseconds=1000))
Out[3]: 10
```

Also fixes this bug:
```python
In [5]: time_in_seconds(datetime.datetime(1970, 1, 1))
Out[5]: -27000.0
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alisaifee/hiro/3)
<!-- Reviewable:end -->
