### PR TITLE
Fix tests in non-UTC timezone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ python:
     - "3.4"
     - "3.5"
     - "pypy"
+env:
+  matrix:
+    - TZ=UTC
+    - TZ=Europe/Paris
+    - TZ=Asia/Hong_Kong
 
 install:
     - pip install -r requirements/ci.txt

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,10 @@
 import datetime
+import time
 import unittest
 
 import hiro
 from hiro.errors import InvalidTypeError
-from hiro.utils import timedelta_to_seconds, time_in_seconds, chained
+from hiro.utils import timedelta_to_seconds, time_in_seconds, chained, utc
 
 
 class TestTimeDeltaToSeconds(unittest.TestCase):
@@ -26,8 +27,15 @@ class TestTimeInSeconds(unittest.TestCase):
         d = datetime.date(1970, 1, 1)
         self.assertEqual(time_in_seconds(d), 0)
 
+        d = d + datetime.timedelta(days=1234)
+        self.assertEqual(time_in_seconds(d), 1234 * 24 * 60 * 60)
+
     def test_datetime(self):
         d = datetime.datetime(1970, 1, 1, 0, 0, 0)
+        self.assertEqual(time_in_seconds(d), time.mktime(d.timetuple()))
+
+    def test_tzaware_datetime(self):
+        d = datetime.datetime(1970, 1, 1, 0, 0, 0, tzinfo=utc)
         self.assertEqual(time_in_seconds(d), 0)
 
     def test_invalid_type(self):


### PR DESCRIPTION
Hi,

The friendly folks at https://reproducible-builds.org/ run regular rebuilds of the Debian archive to check for reproducibility For their reproducibility tests, one of the variables they change across builds is the timezone. They've been testing hiro for reproducibility since it was introduced as a Debian package, and its build has consistently failed during the tests when using a non-UTC timezone.

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=855908

This bug was reported against 0.2, but 0.5 suffers from a variant of this bug as well.

I've finally had the time to sit down and track down the issue. It turns out that `utils.time_in_seconds` returns inconsistent results when using naive (non-timezone-aware) datetime objects. To get consistent results, we absolutely need to use UTC timestamps everywhere, else the Timeline changes are skewed by the amount of the timezone's UTC offset.

This somewhat reverts some of @hyperair's changes, but I think the results are more consistent with what Python expects when using naive datetime objects.

The first commit adds TZ variation to the travis build. The second commit is the actual fix for the bug.

Thanks for considering!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alisaifee/hiro/4)
<!-- Reviewable:end -->
